### PR TITLE
Add smoke tests for gazebo commands on Unix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,6 +125,9 @@ test:
     - test -f $PREFIX/bin/gzserver  # [unix]
     - test -f $PREFIX/bin/gzclient  # [unix]
     - test -f $PREFIX/bin/gazebo    # [unix]
+    - gzserver --version | grep "Gazebo multi-robot simulator, version"  # [unix]
+    - gzclient --version | grep "Gazebo multi-robot simulator, version"  # [unix]
+    - gazebo --version | grep "Gazebo multi-robot simulator, version"  # [unix]
 
 about:
   home: http://gazebosim.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - 2906.patch
 
 build:
-  number: 7
+  number: 8
   skip: false
   run_exports:
     - {{ pin_subpackage('gazebo', max_pin='x') }}


### PR DESCRIPTION
Added some simple execution of the Gazebo commands and check of their output. This should permit to debug if https://github.com/RoboStack/ros-noetic/issues/55 is a problem in the generated binary or some specific problem in the user system. 